### PR TITLE
Fixes build tools link

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                             <div class="host__details">
                                 <h4>Gavin Davies</h4>
                                 <p>
-                                    Gavin is a developer and automation engineer for <a href="//radify.io">Radify</a> who believes that the best way to challenge yourself professionally is to freely share your knowledge with others. He is the author of the books "<a href="https://leanpub.com/dealwithit">Deal With It: Attitude for Coders</a>" and "<a href="http://www.fivesimplesteps.com/products/using-build-tools">Using build tools</a>".
+                                    Gavin is a developer and automation engineer for <a href="//radify.io">Radify</a> who believes that the best way to challenge yourself professionally is to freely share your knowledge with others. He is the author of the books "<a href="https://leanpub.com/dealwithit">Deal With It: Attitude for Coders</a>" and "<a href="http://radify.io/blog/using-build-tools/">Using build tools</a>".
                                 </p>
                                 <p class="host__links">Find Gavin on: <a href="https://twitter.com/gavd_uk" class="icon-twitter"><span>Twitter</span></a> <a href="https://github.com/gavd" class="icon-github"><span>Github</span></a></p>
                             </div>


### PR DESCRIPTION
What with 5ss having sadly closed their doors, this patch updates the site to link to the freely downloadable version
